### PR TITLE
Rename to @futurelearn/design-tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fl-design-tokens",
+  "name": "@futurelearn/design-tokens",
   "version": "1.0.0",
   "license": "MIT",
   "description": "FutureLearn Design Tokens",


### PR DESCRIPTION
We recently renamed this in our main application to avoid clashes with another package that also happens to be called `design-tokens` [1]. We don't _need_ to update it here (clearly the names were already not matching:  "fl-design-tokens") but it is probably clearer if we do.