### PR TITLE
Consolidate "type-scale" breakpoints with standard breakpoints

### DIFF
--- a/build/js/breakpoints.js
+++ b/build/js/breakpoints.js
@@ -1,7 +1,7 @@
 module.exports.typeScaleMedium = 680;
-module.exports.typeScaleLarge = 1695;
+module.exports.typeScaleLarge = 1600;
 module.exports.small = 480;
-module.exports.medium = 648;
+module.exports.medium = 680;
 module.exports.large = 900;
 module.exports.xlarge = 1280;
 module.exports.xxlarge = 1600;

--- a/build/scss/_breakpoints.scss
+++ b/build/scss/_breakpoints.scss
@@ -1,14 +1,14 @@
 
-/*
-  Do not edit directly
-  Generated on Fri, 14 Feb 2020 18:09:14 GMT
-*/
+/**
+ * Do not edit directly
+ * Generated on Wed, 17 Nov 2021 09:50:48 GMT
+ */
 
 $breakpoints: (
   'type-scale-medium': 680,
-  'type-scale-large': 1695,
+  'type-scale-large': 1600,
   'small': 480,
-  'medium': 648,
+  'medium': 680,
   'large': 900,
   'xlarge': 1280,
   'xxlarge': 1600,

--- a/build/scss/_variables.scss
+++ b/build/scss/_variables.scss
@@ -1,11 +1,11 @@
 
 // Do not edit directly
-// Generated on Fri, 14 Feb 2020 18:09:14 GMT
+// Generated on Wed, 17 Nov 2021 09:50:48 GMT
 
 $breakpoint-type-scale-medium: 680;
-$breakpoint-type-scale-large: 1695;
+$breakpoint-type-scale-large: 1600;
 $breakpoint-small: 480;
-$breakpoint-medium: 648;
+$breakpoint-medium: 680;
 $breakpoint-large: 900;
 $breakpoint-xlarge: 1280;
 $breakpoint-xxlarge: 1600;

--- a/tokens/breakpoint.json
+++ b/tokens/breakpoint.json
@@ -1,9 +1,9 @@
 {
   "breakpoint": {
     "type-scale-medium": { "value": 680 },
-    "type-scale-large": { "value": 1695 },
+    "type-scale-large": { "value": 1600 },
     "small": { "value": 480 },
-    "medium": { "value": 648 },
+    "medium": { "value": 680 },
     "large": { "value": 900 },
     "xlarge": { "value": 1280 },
     "xxlarge": { "value": 1600 },


### PR DESCRIPTION
**Trello:** https://trello.com/c/lj4H3kYO

## Commit message:

We have a couple of "type-scale" breakpoints that define where our font
changes size. Slightly awkwardly, these don't line up with our main
breakpoints, though they're quite close to them.

This has the effect that there's a couple of "ghost breakpoints" between
648px and 680px, and again between 1600px and 1695px, in which the
layout can be unexpectedly different (the font size change at 680px in
particular can cause quite significant layout changes).

If we can reconcile these breakpoints with each other we can remove these
"ghost" breakpoints, and simplify things a bit.

I recently opened [an RFC][1] proposing that we reconcile these
breakpoints in order to remove these unpredictable ghost breakpoints and
simplify things a bit.

Let's do this now, by:

- Increasing the "medium" breakpoint to match the "typeScaleMedium"
  breakpoint at 680px (this seems safer than trying to increase the font
  size at a smaller screen size)

- Reducing the "typeScaleLarge" breakpoint to match the "xxlarge"
  breakpoint at 1600px (since this is already wider than most page
  content containers, reducing it seems less likely to cause problems
  in this case

(See the RFC if you'd like even more detail).

This leaves us temporarily with some identical breakpoints. We can
subsequently tidy this up by replacing all references to the typescale
breakpoints in our code with references to their standard breakpoint
equivalent. Once that's done, we should be able to remove the typescale
breakpoint design tokens altogether.

[1]: https://docs.google.com/document/d/1OwF96r9g1rE28eLeHU4Gcufmp4jwMbAaJi5PE79NfxA/edit?usp=sharing

## Notes

In the [`futurelearn` repo](https://github.com/futurelearn/futurelearn/blob/master/package.json#L153) the version of `design-tokens` we use is
locked to a particular commit, whereas in the [`design-system` repo
it isn't](https://github.com/futurelearn/design-system/blob/main/package.json#L36). As a result, I think when this PR is merged to master it will
apply to the design system without any further update needed.

In the case of `futurelearn`, we'll need to also update the dependency
there to point to the latest version of the tokens once this change
is merged.