### PR TITLE
Update Style Dictionary to 3.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "FutureLearn Design Tokens",
   "repository": "https://github.com/futurelearn/design-tokens",
   "devDependencies": {
-    "style-dictionary": "^3.0.0"
+    "style-dictionary": "^3.1.1"
   },
   "scripts": {
     "build": "node ./build.js"

--- a/yarn.lock
+++ b/yarn.lock
@@ -173,6 +173,11 @@ json5@^2.1.3:
   dependencies:
     minimist "^1.2.5"
 
+jsonc-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.0.0.tgz#abdd785701c7e7eaca8a9ec8cf070ca51a745a22"
+  integrity sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==
+
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
@@ -265,10 +270,10 @@ snake-case@^3.0.4:
     dot-case "^3.0.4"
     tslib "^2.0.3"
 
-style-dictionary@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/style-dictionary/-/style-dictionary-3.0.2.tgz#638caa5a6d0c47cc71a41154b5c940ab2835359a"
-  integrity sha512-3fiSzbMG5nY174OrJQpK1JblEHAvZZjn4VRxbgR4Z1b75O60s8RSIeai4DDFEgEBr7eBQpFBnofgParsVeulpg==
+style-dictionary@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/style-dictionary/-/style-dictionary-3.1.1.tgz#780ffebc64a537b877ee5580bd9a937a4ea9ae0a"
+  integrity sha512-Dpugx2wH3ElMvq1GOaSsfUChr8dwujx2/eBUUd0vaSFkP16LRp5XOJMTHF0f8QuPGkpBfVPXDWCkb3oJ3oJjxg==
   dependencies:
     chalk "^4.0.0"
     change-case "^4.1.2"
@@ -276,6 +281,7 @@ style-dictionary@^3.0.0:
     fs-extra "^8.1.0"
     glob "^7.1.6"
     json5 "^2.1.3"
+    jsonc-parser "^3.0.0"
     lodash "^4.17.15"
     tinycolor2 "^1.4.1"
 


### PR DESCRIPTION
## Commit message

There's a dependabot alert warning us to upgrade lodash to version
4.17.21 or later. lodash is a dependency of Style Dictionary, and
Style Dictionary v3.1.0 updated lodash to a suitable version [1].

Rather than upgrade lodash directly, let's update to the latest version
of Style Dictionary (currently 3.1.1) - this should also update lodash
and so keep dependabot happy.

[1]: https://github.com/amzn/style-dictionary/releases/tag/v3.1.0

## Notes

Having updated Style Dictionary locally, I deleted the `build` directory 
and ran `yarn run build`, which recreated it without any issues, and with
identical output (apart from the "generated at" timestamps) so this
update seems safe to me.