### PR TITLE
Remove typescale breakpoint design tokens

### DIFF
--- a/build/js/breakpoints.js
+++ b/build/js/breakpoints.js
@@ -1,5 +1,3 @@
-module.exports.typeScaleMedium = 680;
-module.exports.typeScaleLarge = 1600;
 module.exports.small = 480;
 module.exports.medium = 680;
 module.exports.large = 900;

--- a/build/scss/_breakpoints.scss
+++ b/build/scss/_breakpoints.scss
@@ -1,12 +1,10 @@
 
 /**
  * Do not edit directly
- * Generated on Wed, 17 Nov 2021 09:50:48 GMT
+ * Generated on Mon, 17 Jan 2022 18:22:13 GMT
  */
 
 $breakpoints: (
-  'type-scale-medium': 680,
-  'type-scale-large': 1600,
   'small': 480,
   'medium': 680,
   'large': 900,

--- a/build/scss/_variables.scss
+++ b/build/scss/_variables.scss
@@ -1,9 +1,7 @@
 
 // Do not edit directly
-// Generated on Wed, 17 Nov 2021 09:50:48 GMT
+// Generated on Mon, 17 Jan 2022 18:22:13 GMT
 
-$breakpoint-type-scale-medium: 680;
-$breakpoint-type-scale-large: 1600;
 $breakpoint-small: 480;
 $breakpoint-medium: 680;
 $breakpoint-large: 900;

--- a/tokens/breakpoint.json
+++ b/tokens/breakpoint.json
@@ -1,7 +1,5 @@
 {
   "breakpoint": {
-    "type-scale-medium": { "value": 680 },
-    "type-scale-large": { "value": 1600 },
     "small": { "value": 480 },
     "medium": { "value": 680 },
     "large": { "value": 900 },


### PR DESCRIPTION
## Commit message

**Trello:** https://trello.com/c/lj4H3kYO

These two breakpoints were previously consolidated with the "medium"
and "xxlarge" breakpoints [1]. Having done this, we replaced all
references to them in the `futurelearn` repo [2] and the `design-system`
repo [3] with their equivalent standard breakpoint (ie. "medium" or
"xxlarge").

Having done this - and since there are no references to either breakpoint
in the `frontend` repo either - these breakpoints are no longer
referenced anywhere in our code and so can be removed.

[1]: https://github.com/futurelearn/design-tokens/pull/5
[2]: https://github.com/futurelearn/futurelearn/pull/10934
[3]: https://github.com/futurelearn/design-system/pull/336

## Notes

This is the last step in the slightly protracted "removing the typescale
breakpoints" process. As far as I can see, all references to these
breakpoints are now removed from our code, so I think it should now be
safe to delete them from the design tokens too.

[4]: https://github.com/futurelearn/futurelearn/pull/11420

## Questions / Feedback

Apart from searching the codebase (`futurelearn`, `design-system` and
`frontend`) for references to these tokens, I've also deployed [a 
playground][5] that [updates `futurelearn`][6] to use this version of the
tokens with these two breakpoints removed. Mainly this was to make
sure that removing these didn't cause any build / deploy issues - it
seemed _possible_ that an overlooked `import` of a value that no
longer exists (or an undeclared Sass variable? could cause issues for
webpack that might cause a build failure. However, the playground
deployed fine, which reassures me that this change shouldn't cause
any issues like that.

My main question is: can you think of anything else I should check,
or - given the above - does this seem ok to go ahead and merge?

[5]: https://design-tokens.playground.futurelearn.com
[6]: https://github.com/futurelearn/futurelearn/commit/975e30872a591a3595e4df86d4a1aea33ae15e55

