### PR TITLE
Remove Cyber Discovery related colours

### DIFF
--- a/build/js/colors.js
+++ b/build/js/colors.js
@@ -25,4 +25,3 @@ module.exports.offBrandWhatsappGreen = "#128c7e";
 module.exports.offBrandGreatCampaignColor = "#ffc288";
 module.exports.offBrandGreatCampaignColorLight = "#ffe49e";
 module.exports.offBrandGreatCampaignRibbon = "#cc1474";
-module.exports.offBrandCyberDiscovery = "#0d2332";

--- a/build/scss/_breakpoints.scss
+++ b/build/scss/_breakpoints.scss
@@ -1,7 +1,7 @@
 
 /**
  * Do not edit directly
- * Generated on Mon, 16 May 2022 13:50:53 GMT
+ * Generated on Thu, 23 Jun 2022 11:38:51 GMT
  */
 
 $breakpoints: (

--- a/build/scss/_colors.scss
+++ b/build/scss/_colors.scss
@@ -1,7 +1,7 @@
 
 /**
  * Do not edit directly
- * Generated on Mon, 16 May 2022 13:50:53 GMT
+ * Generated on Thu, 23 Jun 2022 11:38:51 GMT
  */
 
 $colors: (
@@ -32,6 +32,5 @@ $colors: (
   'off-brand-whatsapp-green': #128c7e,
   'off-brand-great-campaign-color': #ffc288,
   'off-brand-great-campaign-color-light': #ffe49e,
-  'off-brand-great-campaign-ribbon': #cc1474,
-  'off-brand-cyber-discovery': #0d2332
+  'off-brand-great-campaign-ribbon': #cc1474
 );

--- a/build/scss/_custom-properties.scss
+++ b/build/scss/_custom-properties.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 16 May 2022 13:50:53 GMT
+ * Generated on Thu, 23 Jun 2022 11:38:51 GMT
  */
 
 :root {
@@ -31,7 +31,6 @@
   --color-off-brand-great-campaign-color: #ffc288;
   --color-off-brand-great-campaign-color-light: #ffe49e;
   --color-off-brand-great-campaign-ribbon: #cc1474;
-  --color-off-brand-cyber-discovery: #0d2332;
   --time-short: 0.30s;
   --time-medium: 0.40s;
   --time-long: 0.60s;

--- a/build/scss/_durations.scss
+++ b/build/scss/_durations.scss
@@ -1,7 +1,7 @@
 
 /**
  * Do not edit directly
- * Generated on Mon, 16 May 2022 13:50:53 GMT
+ * Generated on Thu, 23 Jun 2022 11:38:51 GMT
  */
 
 $durations: (

--- a/build/scss/_easings.scss
+++ b/build/scss/_easings.scss
@@ -1,7 +1,7 @@
 
 /**
  * Do not edit directly
- * Generated on Mon, 16 May 2022 13:50:53 GMT
+ * Generated on Thu, 23 Jun 2022 11:38:51 GMT
  */
 
 $easings: (

--- a/build/scss/_variables.scss
+++ b/build/scss/_variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 16 May 2022 13:50:53 GMT
+// Generated on Thu, 23 Jun 2022 11:38:51 GMT
 
 $breakpoint-small: 480;
 $breakpoint-medium: 680;
@@ -35,7 +35,6 @@ $color-off-brand-whatsapp-green: #128c7e;
 $color-off-brand-great-campaign-color: #ffc288;
 $color-off-brand-great-campaign-color-light: #ffe49e;
 $color-off-brand-great-campaign-ribbon: #cc1474;
-$color-off-brand-cyber-discovery: #0d2332;
 $time-short: 0.30s;
 $time-medium: 0.40s;
 $time-long: 0.60s;

--- a/build/sketch/tokens.sketchpalette
+++ b/build/sketch/tokens.sketchpalette
@@ -190,13 +190,6 @@
       "green": "0.07843",
       "blue": "0.45490",
       "alpha": 1
-    },
-    {
-      "name": "Cyber Discovery",
-      "red": "0.05098",
-      "green": "0.13725",
-      "blue": "0.19608",
-      "alpha": 1
     }
   ]
 }

--- a/tokens/color.json
+++ b/tokens/color.json
@@ -27,8 +27,7 @@
       "whatsapp-green": { "value": "#128c7e" },
       "great-campaign-color": { "value": "#ffc288" },
       "great-campaign-color-light": { "value": "#ffe49e" },
-      "great-campaign-ribbon": { "value": "#cc1474" },
-      "cyber-discovery":  { "value": "#0d2332" }
+      "great-campaign-ribbon": { "value": "#cc1474" }
     }
   }
 }


### PR DESCRIPTION
TC: https://trello.com/c/W63RGLTO/

Cyber Discovery campaign was terminated and we have no legal obligation
to keep this code. We are removing all Cyber Discovery related code in
the main repo in PR [1] and this removes the associated colour in
Design-Tokens.

[1] futurelearn/futurelearn#12802